### PR TITLE
Raise default ReST error report level. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@
 4.0.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Raise the docutils ReST error report level from its default of
+  ``error`` to ``severe``. An error report level issued for directives
+  that are unknown, such as ``:class:``, which are increasingly common
+  due to the use of Sphinx. This change prevents an error being
+  printed on stderr as well as rendered in the HTML.
 
 
 4.0.0 (2017-05-17)

--- a/src/zope/app/renderer/rest.py
+++ b/src/zope/app/renderer/rest.py
@@ -103,7 +103,8 @@ class ReStructuredTextToHTMLRenderer(BrowserView):
         """
         # default settings for the renderer
         overrides = {
-            'halt_level': 6,
+            'halt_level': 6, # don't stop for any errors
+            'report_level': 4, # only report severe errors
             'input_encoding': 'unicode',
             'output_encoding': 'unicode',
             'initial_header_level': 3,


### PR DESCRIPTION
Refs zopefoundation/zope.app.apidoc#4